### PR TITLE
Feat: Add auto detect default gateway device name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Change these parameters to match your setup
 - MAX_CLIENTS="5" # Number of client config will be generated
 - SERVER_IP="192.168.0.10" # Your server public IP Adress that client will connect to
 - SERVER_PORT="56789" # Define port that VPN Service will listen on (UDP)
-- DEVICE="ens192" # Name of the network interface corresponding to SERVER_IP (used in iptables NAT rule)
+- DEVICE="ens192" # Name of the network interface corresponding to SERVER_IP (used in iptables NAT rule) or you can leave it as blank to auto detect
 - DISABLE_SELINUX="0" # CHANGE to 1: If you want to disable selinux (CentOS)
 - DISALBE_FIREWALLD="0" # CHANGE to 1: If you want to disable Firewalld (CentOS)
 - TUNNEL_ADDR_PREFIX="10.8.0" # Local IP address for client after connect to VPN Server

--- a/wireguard_setup.sh
+++ b/wireguard_setup.sh
@@ -4,7 +4,7 @@
 MAX_CLIENTS="5" # Number of client config will be generated
 SERVER_IP="192.168.0.10" # CHANGE ME
 SERVER_PORT="56789" # CHANGE ME
-DEVICE="ens192" # CHANGE ME
+DEVICE="" # CHANGE ME or leave it as blank to auto detect
 DISABLE_SELINUX="0" # CHANGE to 1: If you want to disable selinux (CentOS)
 DISALBE_FIREWALLD="0" # CHANGE to 1: If you want to disable Firewalld (CentOS)
 TUNNEL_ADDR_PREFIX="10.8.0"
@@ -134,6 +134,17 @@ function gen_server_config() {
 	fi
 
 	server_pri_key=$(cat "${KEYS_DIR}/server_private.key")
+
+	# Check default gateway device interface name
+	if [[ -z "${DEVICE}" ]];then
+		if [[ "$(ip r | grep default | wc -l)" -gt 1 ]];then
+			echo "WARN: variable DEVICE is missing or you have more than one default route with multiple priority metrics. Please recheck."
+			sleep 5
+		else
+			DEVICE=$(ip r | grep default | head -n 1 | grep -oP '(?<=dev )[^ ]*')
+			echo $DEVICE
+		fi
+	fi
 
 	# Server base config
 	cat > $SERVER_CONFIG <<EOF

--- a/wireguard_setup.sh
+++ b/wireguard_setup.sh
@@ -138,11 +138,10 @@ function gen_server_config() {
 	# Check default gateway device interface name
 	if [[ -z "${DEVICE}" ]];then
 		if [[ "$(ip r | grep default | wc -l)" -gt 1 ]];then
-			echo "WARN: variable DEVICE is missing or you have more than one default route with multiple priority metrics. Please recheck."
+			echo "WARN: variable DEVICE is missing or you have more than one default route with multiple priority metrics. Please recheck and rerun."
 			sleep 5
 		else
 			DEVICE=$(ip r | grep default | head -n 1 | grep -oP '(?<=dev )[^ ]*')
-			echo $DEVICE
 		fi
 	fi
 


### PR DESCRIPTION
## Description

- We add one more step to auto detect default gateway device name if user leave variable `DEVICE` as blank.
- In case we have more than one default route with multiple priority metrics. It will do not auto detect.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Apply a semantic versioning label to your Merge Request (patch, minor, major,.. ) depending on nature of change.

